### PR TITLE
Removing dependency styling_profiles_domain_switch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
     "drupal/core": ">=8.6",
     "drupal/domain": "*",
     "drupal/domain_site_settings": "*",
-    "iqual/styling_profiles": "*",
     "iqual/rancher-api": "*"
   },
   "extra": {

--- a/iq_multidomain_extensions.info.yml
+++ b/iq_multidomain_extensions.info.yml
@@ -8,4 +8,3 @@ dependencies:
   - domain:domain
   - domain:domain_source
   - domain_site_settings:domain_site_settings
-  - styling_profiles:styling_profiles_domain_switch

--- a/src/DomainForm.php
+++ b/src/DomainForm.php
@@ -64,14 +64,14 @@ class DomainForm extends OrigForm {
           '#disabled' => !$domainThemeSwitch,
         ];
       }
-      if ($stylingProfileThemeSwitch) {
-        $form['extensions']['create_styling_profile'] = [
-          '#type' => 'checkbox',
-          '#title' => $this->t('Create styling profile'),
-          '#description' => $this->t('Whether to automatically create a styling profile with each new domain.'),
-          '#default_value' => $baseConfig->get('create_styling_profile'),
-        ];
-      }
+      $form['extensions']['create_styling_profile'] = [
+        '#type' => 'checkbox',
+        '#title' => $this->t('Create styling profile'),
+        '#description' => $this->t('Whether to automatically create a styling profile with each new domain.')   . ((!$stylingProfileThemeSwitch) ? '<br />' . $this->t('Only available if styling_profiles_domain_switch is installed.') : ''),
+        '#default_value' => $baseConfig->get('create_styling_profile'),
+        '#disabled' => !$stylingProfileThemeSwitch,
+      ];
+
       $form['#isnew'] = TRUE;
       $form['hostname']['#field_suffix'] = '.' . getenv('DOMAIN_BASE');
       $form['hostname']['#default_value'] = str_replace('.' . getenv('DOMAIN_BASE'), '', $form['hostname']['#default_value']);

--- a/src/Service/DomainService.php
+++ b/src/Service/DomainService.php
@@ -274,9 +274,12 @@ class DomainService {
   public function createStylingProfile(string $label, string $id) {
     $profile = StylingProfile::create(['id' => $id, 'label' => $label]);
     $profile->save();
-    $config = \Drupal::service('config.factory')->getEditable('styling_profiles_domain_switch.settings');
-    $config->set($id, $profile->id());
-    $config->save();
+    $stylingProfileThemeSwitch = $moduleHandler->moduleExists('styling_profiles_domain_switch');
+    if ($stylingProfileThemeSwitch) {
+      $config = \Drupal::service('config.factory')->getEditable('styling_profiles_domain_switch.settings');
+      $config->set($id, $profile->id());
+      $config->save(); 
+    }
   }
 
   /**


### PR DESCRIPTION
iq_barrio_helper is required by iq_multidomain_extensions > styling_profiles_domain_switch > styling_profiles > iq_barrio_helper

Which causes `iq_barrio_helper_install()` to run on site-install, e.g. during local development.
Plus, it is probably less generic the way it is right now.