### PR TITLE
Add additional routing options for `/robots.txt` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,36 @@ Once installed, a new field is available on the domain site settings for the fav
 /admin/config/domain/domain_site_settings/{domain}/edit
 
 ### Robots.txt
-If you want to register a robots.txt file per domain, you must activate iq_multidomain_robotstxt_extension. Install it with
+If you want to register a `robots.txt` file per domain, you must activate iq_multidomain_robotstxt_extension. Install it with
 
     drush en iq_multidomain_robotstxt_extension
 
 Once installed, a new field is available on the domain site settings for the robots.txt content.
 /admin/config/domain/domain_site_settings/{domain}/edit
 
+Additionally incoming public requests have to be passed to the module (i.e. PHP) on either the `/robots` or `/robots.txt` path.
+
+#### Kubernetes nginx ingress setup
+
 You also need to add the following annotation to all main domain ingresses on rancher:
-nginx.ingress.kubernetes.io/configuration-snippet=location = /robots.txt {  rewrite ^ /robots last; }
-This redirects requests to robot.txt to the correct dynamic endpoint.
+
+```yaml
+nginx.ingress.kubernetes.io/configuration-snippet: |-
+  location = /robots.txt {
+    rewrite ^ /robots last;
+  }
+```
+
+> It is also advised to enable the www-redirect option and to not set the `www` or non-`www` domain in the ingress respectively. (i.e. `nginx.ingress.kubernetes.io/from-to-www-redirect: "true"`)
+
+This rewrites incoming requests to `robots.txt` to the correct dynamic endpoint (`/robots`) bypassing any existing robots file.
+
+#### Nginx example
+
+If you want to pass the request to php directly in your application nginx, you can use an approach like this:
+
+```nginx
+location = /robots.txt {
+    rewrite ^ /index.php last;
+}
+```

--- a/modules/iq_multidomain_robotstxt_extension/iq_multidomain_robotstxt_extension.routing.yml
+++ b/modules/iq_multidomain_robotstxt_extension/iq_multidomain_robotstxt_extension.routing.yml
@@ -15,3 +15,11 @@ iq_multidomain_robotstxt_extension.routing.robots.content:
     _disable_route_normalizer: 'TRUE'
   requirements:
     _access: 'TRUE'
+
+iq_multidomain_robotstxt_extension.routing.robotstxt.content:
+  path: '/robots.txt'
+  defaults:
+    _controller: '\Drupal\iq_multidomain_robotstxt_extension\Controller\RobotsTxtController::content'
+    _disable_route_normalizer: 'TRUE'
+  requirements:
+    _access: 'TRUE'


### PR DESCRIPTION
Currently if you want to pass a `/robots.txt` request to the module the request has to be rewritten to `/robots` (on the reverse proxy before reaching the application). In order to enable this to work on other setups, we should also add the ability to pass a `/robots.txt` request directly to php (i.e. on the application web server).

Example nginx configuration:
```nginx
location = /robots.txt {
    rewrite ^ /index.php last;
}
```

This issue appeared when setting up multi-domain on Platform.sh.

Should this feature be added to `2.x`, `3.x` or both?