### PR TITLE
DUP-61: allow access to node if published, by passing the domain access check

### DIFF
--- a/modules/iq_multidomain_sitemap_extension/iq_multidomain_sitemap_extension.module
+++ b/modules/iq_multidomain_sitemap_extension/iq_multidomain_sitemap_extension.module
@@ -132,3 +132,17 @@ function _iq_multidomain_sitemap_extension_target_matches($params, $sitemap) {
   }
   return TRUE;
 }
+
+/**
+ * Implements hook_xmlsitemap_link_alter().
+ */
+function iq_multidomain_sitemap_extension_xmlsitemap_link_alter(array &$link, array $context) {
+  $entity = $context['entity'];
+  if (
+    $link['loc'] &&
+    $entity instanceof NodeInterface &&
+    $entity->isPublished()
+  ) {
+    $link['access'] = TRUE;
+  }
+}

--- a/modules/iq_multidomain_sitemap_extension/iq_multidomain_sitemap_extension.module
+++ b/modules/iq_multidomain_sitemap_extension/iq_multidomain_sitemap_extension.module
@@ -139,6 +139,7 @@ function _iq_multidomain_sitemap_extension_target_matches($params, $sitemap) {
 function iq_multidomain_sitemap_extension_xmlsitemap_link_alter(array &$link, array $context) {
   $node = $context['node'];
   if (
+    $node &&
     $link['loc'] &&
     $node->isPublished()
   ) {

--- a/modules/iq_multidomain_sitemap_extension/iq_multidomain_sitemap_extension.module
+++ b/modules/iq_multidomain_sitemap_extension/iq_multidomain_sitemap_extension.module
@@ -140,7 +140,7 @@ function iq_multidomain_sitemap_extension_xmlsitemap_link_alter(array &$link, ar
   $node = $context['node'];
   if (
     $link['loc'] &&
-    $entity->isPublished()
+    $node->isPublished()
   ) {
     $link['access'] = TRUE;
   }

--- a/modules/iq_multidomain_sitemap_extension/iq_multidomain_sitemap_extension.module
+++ b/modules/iq_multidomain_sitemap_extension/iq_multidomain_sitemap_extension.module
@@ -137,10 +137,9 @@ function _iq_multidomain_sitemap_extension_target_matches($params, $sitemap) {
  * Implements hook_xmlsitemap_link_alter().
  */
 function iq_multidomain_sitemap_extension_xmlsitemap_link_alter(array &$link, array $context) {
-  $entity = $context['entity'];
+  $node = $context['node'];
   if (
     $link['loc'] &&
-    $entity instanceof NodeInterface &&
     $entity->isPublished()
   ) {
     $link['access'] = TRUE;


### PR DESCRIPTION
Projects using xmlsitemap along with domain_access have issue generating proper sitemap.xml files.

Links are displayed in the sitemap file only if access is granted for the related entity. When generating a sitemap from the UI admin of a given domain, all nodes/entities not having this domain as domain access will be considered as not accessible.
Relevant code [here](https://git.drupalcode.org/project/xmlsitemap/-/blob/8.x-1.x/src/XmlSitemapLinkStorage.php?ref_type=heads#L158)

This PR gives a quick workaround for node entities by forcing the access to true if they are published

But a better solution would probably be to limit sitemap generation to the current domain only / or to provide a node access check per domain.